### PR TITLE
Remove /opt bits - so my entire /opt doesn't become readonly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ RUN mkdir -p /work/usr/lib/extension-release.d && echo -e 'ID=flatcar\nSYSEXT_LE
 RUN mkdir -p /work/usr/src
 RUN mv /work/etc /work/usr/etc
 COPY usr /work/usr
+RUN mv /work/opt/cni /work/usr/lib/cni
+RUN rm -rf /work/var /work/usr/include /work/usr/lib*/cmake
+RUN rmdir /work/opt
 RUN mkdir -p /output && mksquashfs /work /output/podman.raw -noappend
 
 FROM busybox

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG FLATCAR_VERSION=3200.0.0
+ARG FLATCAR_VERSION=3227.2.2
 
 FROM mediadepot/flatcar-developer:${FLATCAR_VERSION} AS base
 
@@ -21,8 +21,8 @@ RUN mkdir -p /work/usr/lib/extension-release.d && echo -e 'ID=flatcar\nSYSEXT_LE
 RUN mkdir -p /work/usr/src
 RUN mv /work/etc /work/usr/etc
 COPY usr /work/usr
-RUN mv /work/opt/cni /work/usr/lib/cni
-RUN rm -rf /work/var /work/usr/include /work/usr/lib*/cmake
+RUN mv /work/opt/cni/bin /work/usr/lib/cni
+RUN rm -rf /work/var /work/usr/include /work/usr/lib*/cmake /work/opt/cni
 RUN rmdir /work/opt
 RUN mkdir -p /output && mksquashfs /work /output/podman.raw -noappend
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,12 @@ RUN rm -rf /work/var /work/usr/include /work/usr/lib*/cmake /work/opt/cni
 RUN rmdir /work/opt
 RUN mkdir -p /output && mksquashfs /work /output/podman.raw -noappend
 
+FROM busybox AS torcx
+RUN mkdir /work /output
+COPY torcx /work
+RUN tar -zcvf /output/docker:podman.torcx.tgz -C /work .
+
 FROM busybox
 COPY --from=staging /output /output
-CMD ["cp", "/output/podman.raw", "/out"]
+COPY --from=torcx /output /output
+CMD ["cp", "/output/podman.raw", "/output/docker:podman.torcx.tgz", "/out"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TAG = dev:latest
-FLATCAR_VERSION = 3200.0.0
+FLATCAR_VERSION = 3227.2.2
 OVERLAY_DIR = /var/lib/portage/podman-overlay
 
 podman.raw: container

--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 # Build
 
 ```
-make snapd.raw
+make podman.raw
 ```
 
 # Use
 
-Copy snapd.raw to /etc/extensions.
+Copy podman.raw to /etc/extensions.
 
 Disable selinux in /etc/selinux/config - must be disabled not permissive. Default file is a symlink so make a copy (`cp /etc/selinux/config{,-}; mv /etc/selinux/config{-,}`)
 
-Run `systemctl enable --now snapd.socket`
+Symlink the CNI plugins `ln -sf /usr/lib/cni/ /opt/cni/`
+
+Copy configs from /usr/etc/ into the appropriate directories in /etc.  Remove the .example extensions.
+
+Run `systemctl enable --now podman.socket`
 
 # Test
 
@@ -19,4 +23,4 @@ snap install hello-world
 snap run hello-world
 ```
 
-To make snaps accessible, add /var/lib/snapd/snap/bin to $PATH.
+To make snaps accessible, add /var/lib/podman/snap/bin to $PATH.

--- a/torcx/.torcx/manifest.json
+++ b/torcx/.torcx/manifest.json
@@ -1,0 +1,8 @@
+{
+    "kind": "image-manifest-v0",
+    "value": {
+        "bin": [
+            "/bin/docker"
+        ]
+    }
+}

--- a/torcx/bin/docker
+++ b/torcx/bin/docker
@@ -1,0 +1,7 @@
+#!/usr/bin/bash
+
+[ -e /etc/containers/nodocker ] || \
+echo "Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg." >&2
+
+exec /usr/bin/podman "$@"
+

--- a/usr/lib/systemd/network/50-podman.network
+++ b/usr/lib/systemd/network/50-podman.network
@@ -1,0 +1,7 @@
+[Match]
+Type=bridge
+Name=cni-* br-*
+
+[Link]
+Unmanaged=yes
+

--- a/usr/lib/systemd/network/90-veth.network
+++ b/usr/lib/systemd/network/90-veth.network
@@ -1,0 +1,6 @@
+[Match]
+Driver=veth
+
+[Link]
+Unmanaged=yes
+


### PR DESCRIPTION
Remove /opt bits - so my entire /opt doesn't become readonly
Drop the includes, and cmake stuff, and things flatcar runtime doesn't need.
Tweak the README.md.
